### PR TITLE
Replacing spaces in network names to prevent reading errors from Prometheus

### DIFF
--- a/changelog/unreleased/fix-network-name.md
+++ b/changelog/unreleased/fix-network-name.md
@@ -1,0 +1,4 @@
+Bugfix : Network names can include a space
+
+Fixed issue #142, where a network name included a space. 
+This caused the network label to include that space and prevented Prometheus from reading the output file

--- a/pkg/action/discoverer.go
+++ b/pkg/action/discoverer.go
@@ -285,6 +285,7 @@ func normalizeLabel(val string) string {
 		"-": "_",
 		".": "_",
 		",": "_",
+		" ": "_",
 	}
 
 	for original, replaced := range replaces {


### PR DESCRIPTION
Fixes a bug that prevents prometheus from reading the output file, due to the presence of spaces in network names (fixes issue #142)